### PR TITLE
docs: improve documentation and scripts, provide script as executables

### DIFF
--- a/docs/build-kernel-kvm-sgx.sh
+++ b/docs/build-kernel-kvm-sgx.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+set -e
+
+# Use $HOME as a working directory for two reasons:
+#
+#   1. keep the built code around instead of putting it into /tmp and loose it
+#      at the next reboot.;
+#
+#   2. avoid $PWD because it may contain white spaces and kbuild would not
+#      work.
+#
+build_dir="$HOME/build-linux-sgx"
+
+version="sgx-v4.19.1-r1"
+suffix="-kvm-sgx"
+git_repo="https://github.com/intel/kvm-sgx.git"
+build_threads="12"
+
+if [ ! -d "$build_dir" ];
+then
+    echo "Making build dir"
+    mkdir "$build_dir"
+fi
+
+cd "$build_dir"
+
+if [ ! -d "kvm-sgx" ];
+then
+    echo "Cloning kernel tag $version"
+    time git clone --depth 1 --branch "$version" "$git_repo"
+fi
+
+cd "$build_dir/kvm-sgx"
+
+echo "Copying config for kernel build"
+cp "$(ls -t /boot/config-* | head -n1)" ".config"
+
+echo "Make oldconfig"
+make olddefconfig >/dev/null
+./scripts/config --module USB_COMMON
+./scripts/config --set-str SYSTEM_TRUSTED_KEYS ""
+
+echo "Setting KVM SGX flag in kernel config"
+./scripts/config --enable INTEL_SGX_CORE
+
+echo "Disabling Debug Components to speed build"
+./scripts/config --disable DEBUG_INFO
+
+echo "Building Kernel"
+time make -j$build_threads bindeb-pkg LOCALVERSION="$suffix" 2> >(tee -a "$build_dir/build-errors.log" >&2)

--- a/docs/build-qemu-sgx.sh
+++ b/docs/build-qemu-sgx.sh
@@ -1,0 +1,80 @@
+#!/bin/sh
+
+set -e
+
+# Use $HOME as a working directory for two reasons:
+#
+#   1. keep the built code around instead of putting it into /tmp and loose it
+#      at the next reboot.;
+#
+#   2. avoid $PWD because it may contain white spaces and kbuild would not
+#      work.
+#
+build_dir="$HOME/build-linux-sgx"
+
+build_threads="12"
+
+[ -d "$build_dir" ] || mkdir "$build_dir"
+
+cd "$build_dir"
+
+[ -d qemu-sgx ] || git clone https://github.com/intel/qemu-sgx.git
+
+cd qemu-sgx/
+
+git submodule update --init
+
+[ -d build/ ] || mkdir build
+
+cd build
+
+# Try to match the configure options of the Debian package
+../configure \
+  --extra-cflags="-I/usr/include/capstone" \
+  --target-list=x86_64-softmmu \
+  --prefix="$PWD/install" \
+  --disable-blobs \
+  --disable-strip \
+  --enable-debug \
+  --disable-werror \
+  --enable-capstone=system \
+  --enable-linux-aio \
+  --audio-drv-list=pa,alsa,oss \
+  --enable-attr \
+  --enable-bluez \
+  --enable-brlapi \
+  --enable-virtfs \
+  --enable-cap-ng \
+  --enable-curl \
+  --enable-fdt \
+  --enable-gnutls \
+  --enable-gtk --enable-vte \
+  --enable-libiscsi \
+  --enable-curses \
+  --enable-virglrenderer \
+  --enable-opengl \
+  --enable-libnfs \
+  --enable-smartcard \
+  --enable-rbd \
+  --enable-glusterfs \
+  --enable-vnc-sasl \
+  --disable-sdl --with-sdlabi=2.0 \
+  --enable-seccomp \
+  --enable-rdma \
+  --enable-libusb \
+  --enable-usb-redir \
+  --enable-libssh2 \
+  --enable-vde \
+  --enable-xfsctl \
+  --enable-vnc \
+  --enable-vnc-jpeg \
+  --enable-vnc-png \
+  --enable-kvm \
+  --enable-vhost-net
+
+make -j$build_threads
+make install
+
+echo
+echo
+echo "qemu can now be run from '$PWD/install/bin'"

--- a/docs/ubuntu-windows-sgx-vm-instructions.md
+++ b/docs/ubuntu-windows-sgx-vm-instructions.md
@@ -1,192 +1,163 @@
+## Ubuntu/Debian KVM SGX Kernel & Windows VM Guide
 
-## Ubuntu KVM SGX Kernel & Windows VM Guide
+This guide will give you the process to get a Windows 10 KVM VM working with Intel SGX to use the fingerprint reader on your XPS 9570/9370.
 
-This guide will give you the process to get a Windows 10 KVM VM working with Intel SGX to use the fingerprint reader on your XPS 9570.
+This makes it possible to capture the USB traffic with [tshark and `usbmon`](https://wiki.wireshark.org/CaptureSetup/USB).
 
 ### 1: Build and install the Intel SGX KVM kernel
 
-It's probably wise to start on a similar kernel version to that which you're building in step 1.2. The kvm-sgx repo use tags for the linux kernel versions, in this guide it's `v4.19.0`. Use `ukuu` or the `mainline` kernel downloads page to get the `v4.19` kernel before hand. 
+It's probably wise to start on a similar kernel version to that which you're building in step 1.2. The kvm-sgx repo use tags for the linux kernel versions, in this guide it's `v4.19.0`. Use `ukuu` or the `mainline` kernel downloads page to get the `v4.19` kernel before hand.
 
-#### 1.1 Install build dependancies
+#### 1.1 Install build dependencies
 
-These packages are needed to build the kernel, there may be others. 
-The libcurses package is needed for the graphical menuconfig.
+These packages are needed to build the kernel, there may be others.
+The libcurses package is needed only in case the graphical menuconfig is used.
+
 ```bash
 sudo apt install git build-essential kernel-package fakeroot libncurses5-dev libssl-dev ccache libncurses-dev bison flex libelf-dev
 ```
 
 #### 1.2 Build the kvm-sgx kernel
 
-The following script will clone the KVM repo and build the kernel for you:
-```bash
-#!/bin/bash
-version="sgx-v4.19.1-r1"
-suffix="-kvm-sgx"
-git_repo="https://github.com/intel/kvm-sgx.git"
-build_dir="/tmp/build-sgx-kernel"
-build_threads="12"
+Run the provided [`build-kernel-kvm-sgx.sh`](build-kernel-kvm-sgx.sh) script to clone the KVM repo and build the kernel automatically.
 
-echo "Making build dir"
-[ -d $build_dir ] || mkdir $build_dir
-
-echo "Cloning kernel tag $version"
-time git clone --depth 1 --branch $version $git_repo $build_dir
-
-echo "Copying config for kernel build"
-cp $(ls -t /boot/config-* | head -n1) $build_dir/.config
-
-echo "Setting KVM SGX flag in kernel config"
-sed -i "s/# CONFIG_INTEL_SGX_CORE is not set/CONFIG_INTEL_SGX_CORE=y/g" $build_dir/.config
-
-cd $build_dir
-
-echo "Disabling Debug Components to speed build"
-scripts/config --disable DEBUG_INFO
-
-echo "Make oldconfig"
-yes "" | make oldconfig >/dev/null
-
-read -n1 -r -p "Press any key to launch make menuconfig" key
-make menuconfig
-
-echo "Building Kernel"
-time make -j$build_threads deb-pkg LOCALVERSION=$suffix >/dev/null 2> >(tee -a $build_dir/build-errors.log >&2)
-```
-During the kernel build you'll get the menuconfig screen appear, you will need to go and enable the SGX driver to be included in the build config. At the top menu, type `/` for search and enter `sgx`. It'll tell you the path in the `driver` menu to enable the `sgx` driver. Once you've located it, press `y` to select, save your config and exit to continue the build.
-
-Copy the contents above into file, make it executable and run it as `sudo`:
-```bash
-cd /tmp
-vim build.sh
-[paste and save]
-chmod +x build.sh
-sudo ./build.sh
-```
+The script will set the necessary kernel configuration for SGX.
 
 #### 1.3 Install the kernel
 
-If all goes well, you'll have the kernel in the parent directory of the `build_dir`. Time to install the kernel, make sure that only the kernel `deb` files you built are in this folder to prevent installing other version first:
+If all goes well, you'll have the kernel inside the `build_dir` (e.g. `$HOME/build-linux-sgx`). Time to install the kernel, make sure that only the kernel `deb` files you built are in this folder to prevent installing other version first:
+
 ```bash
-cd /tmp
+cd $HOME/build-linux-sgx
 ls -la *.deb
 sudo dpkg -i linux-*.deb
 reboot
 ```
 
-**Note:** If the kernel is an older kernel than the version you're currently running, you'll need to make sure your grub config is set to show the boot menu `/etc/default/grub` and on reboot head into Adanced boot options to select the kernel you built. The kernel will have the suffix `-kvm-sgx` next the the version number.
+**Note:** If the kernel is an older kernel than the version you're currently running, you'll need to make sure your grub config is set to show the boot menu `/etc/default/grub` and on reboot head into Advanced boot options to select the kernel you built. The kernel will have the suffix `-kvm-sgx` next to the version number.
 
 ### 2: Install KVM
 
 If you don't have KVM installed already, install it using the following steps.
 
-#### 2.1 Make sure kvm device exists before installing 
+#### 2.1 Make sure kvm device exists before installing
+
+You can use `kvm-ok` from the `cpu-checker` package:
+
 ```bash
 kvm-ok
 ```
+
 Which should output something like
+
 ```bash
 INFO: /dev/kvm exists
 KVM acceleration can be used
 ```
+
 #### 2.2 Install the kvm packages
+
 ```bash
 sudo apt install qemu-kvm libvirt-daemon-system libvirt-clients bridge-utils
 ```
-#### 2.3 Optionally install the virtmanager and stuff
+
+#### 2.3 Optionally install the virt-manager and stuff
+
 ```bash
 sudo apt install virt-manager
 ```
 
 Probably wise to reboot at this stage.
 
-
 ### 3. Build qemu-sgx
 
-#### 3.1 Load the kvm_intel module
 
-You will need to do this on any subsequent reboots I believe:
+#### 3.1 Install build dependencies
 ```bash
-sudo modprobe kvm_intel sgx=0
+ sudo apt build-dep qemu-system-x86
 ```
 
-#### 3.2 Install build dependancies
-```bash
-sudo apt install git git-email libaio-dev libbluetooth-dev libbrlapi-dev libbz2-dev libcap-dev libcap-ng-dev libcurl4-gnutls-dev libfdt-dev libglib2.0-dev libgtk-3-dev libibverbs-dev libjpeg8-dev liblzo2-dev libncurses5-dev libnuma-dev libpixman-1-dev librbd-dev librdmacm-dev libsasl2-dev libsdl1.2-dev libseccomp-dev libsnappy-dev libssh2-1-dev libusb-dev libvde-dev libvdeplug-dev libvte-dev libxen-dev valgrind xfslibs-dev zlib1g-dev libusb-1.0-0-dev
-```
+#### 3.2 Build qemu
 
-**Note:** After you build qemu, you will need to keep the checked out repo folder as the build folder will make symlinks to files in the repo root. I built mine in `/usr/src` and then copied the build folder to `/opt/qemu-sgx` because of linux conventions. 
+Run the provided [`build-qemu-sgx.sh`](build-qemu-sgx.sh) script to clone the qemu-kvm repo and build it automatically.
 
-It's probably better practice to build the package in a non-root folder first and move the `build` folder to where you like later avoiding running `sudo` on builds is wise.
-
-#### 3.3 Build qemu
-```bash
-build_threads="12"
-cd /usr/src
-sudo git clone https://github.com/intel/qemu-sgx.git
-cd qemu-sgx/
-sudo mkdir build
-cd build
-sudo ../configure --target-list=x86_64-softmmu --prefix=/usr --enable-debug --enable-libusb --enable-kvm --enable-seccomp
-sudo make -j$build_threads
-```
-
-#### 3.4 Optional: Copy build folder to a different location
-
-Remember, don't move the git repo clone folder or your symlinks will break!
-```
-cd ..
-sudo cp -r build /opt/qemu-sgx
-```
 
 ### 4. Install Windows with qemu-kvm
 
 Follow the instructions here to setup the Windows vm: [Windows 10 Virtualization with KVM](https://www.funtoo.org/Windows_10_Virtualization_with_KVM)
 
-#### 4.1 Modifications to `vm.sh`
+Or just install Windows 10 with virm-manager using the system qemu, the same image could be run later with qemu-sgx.
 
-- Included the path to the built qemu-sgx
-- Added the `-machine epc=128m` for SGX memory storage
+#### 4.1 Load the kvm_intel module
+
+You will need to do this on any subsequent reboots I believe:
+```bash
+sudo modprobe kvm_intel
+```
+
+#### 4.2 Modifications to qemu command line
+
+You can use the same command used by virt-manager (look at the output of `ps aux | grep [q]emu`) and adjust it to use qemu-sgx, and the fingerpirnt reader:
+
+- Use the path to the built qemu-sgx (e.g. `$HOME/build-linux-sgx/qemu-sgx/build/install/bin/qemu-system-x86_64`)
+- use `-cpu host`
+- Add `epc=128m` to the `-machine` option to enable the SGX memory storage
 - Pass through the fingerprint USB device
+
+**Note:** If virt-manager used a `pc-q35-3.1` machine, change that to `pc-q35-3.0` as qemu-sgx may not be up to date with upstream.
 
 To get the device information run `lsusb` and note the bus and device number:
 ```bash
 lsusb |grep '27c6:5395'
-Bus 001 Device 005: ID 27c6:5395  
+Bus 001 Device 005: ID 27c6:5395
 
 ```
 
-In the `-usb -device` section, make sure the hostbus and hostaddr match bus and device respectively.
+In the `-usb -device` section, make sure the `hostbus` and `hostaddr` match bus and device respectively.
 Also ensure your paths to your `isos` are correct as per the KVM Windows guide.
+
+An example can be the following `vm.sh` script:
+
+
 ```bash
 #!/bin/sh
-WINIMG=$HOME/vm/Win10_1607_EnglishInternational_x64.iso
-VIRTIMG=$HOME/vm/virtio-win-0.1.160.iso
+
+WINIMG="$HOME/vm/Win10_1607_EnglishInternational_x64.iso"
+VIRTIMG="$HOME/vm/virtio-win-0.1.160.iso"
+
 # path to the build folder for qemu-sgx
-QEMUSGX=/opt/qemu-sgx
-/opt/qemu-sgx/x86_64-softmmu/qemu-system-x86_64 -L ${QEMUSGX} --enable-kvm -drive driver=raw,file=$HOME/vm/win10.img,if=virtio -m 2048 \
--net nic,model=virtio -net user -cdrom ${WINIMG} \
--drive file=${VIRTIMG},index=3,media=cdrom \
--usb -device usb-host,hostbus=1,hostaddr=5  \
--machine epc=128m \
--rtc base=localtime,clock=host -smp cores=2,threads=4 \
--usb -device usb-tablet -cpu host
+QEMUSGX="$HOME/qemu-sgx/build/install"
+
+$QEMUSGX/bin/qemu-system-x86_64 \
+  -L "$QEMUSGX/../pc-bios" \
+  --enable-kvm \
+  -cpu host \
+  -machine epc=128m \
+  -m 2048 \
+  -smp cores=2,threads=4 \
+  -rtc base=localtime,clock=host \
+  -drive driver=raw,file=$HOME/vm/win10.img,if=virtio \
+  -drive file=${VIRTIMG},index=3,media=cdrom \
+  -net nic,model=virtio -net user -cdrom ${WINIMG} \
+  -usb -device usb-tablet \
+  -usb -device usb-host,hostbus=1,hostaddr=5
 ```
 
-#### 4.2 Start the Windows VM
+#### 4.3 Start the Windows VM
 
 ```bash
 cd ~/vm
 sudo ./vm.sh
 ```
 
-#### 4.3 Install the drivers
+#### 4.4 Install the drivers
 
 1. Install network `virtio` drivers in device manager
 2. Download and install the Goodix Fingerprint drivers from [Dell Support](https://www.dell.com/support/home/au/en/aubsdt1/product-support/product/xps-15-9570-laptop/drivers)
 3. Install the Intel SGX Driver for [Windows](https://downloadcenter.intel.com/download/28154/Intel-Software-Guard-Extensions-Intel-SGX-Driver-for-Windows-)
 
-Reboot VM
+Reboot the VM.
 
-#### 4.4 Enroll your fingerprint in your account
+#### 4.5 Enroll your fingerprint in your account
 
-Go to Settings > Accounts and find the wizard to enroll your fingerprint. Lock Windows and test it works!
+Go to `Settings > Accounts` and find the wizard to enroll your fingerprint. Lock Windows and test it works!


### PR DESCRIPTION
Improve the already useful documentation and factor out scripts as actual
shell scripts that the user can execute, this is handier and less error
prone.

The documentation provides direct links to the script to make it easier
to download them when following the instructions.

The instructions now use sudo only when it's strictly necessary and
avoid copying files outside of the user home directory as much as
possible.